### PR TITLE
Fixed "next read" link generation error

### DIFF
--- a/src/templates/Article.jsx
+++ b/src/templates/Article.jsx
@@ -30,6 +30,7 @@ const ArticleTemplate = ({
       meta: { updatedAt, firstPublishedAt },
       categoryLink,
       relatedPosts,
+      noTranslate
     },
     datoCmsMiscTextString: { updatedAtText, nextReadText },
   },
@@ -54,6 +55,7 @@ const ArticleTemplate = ({
         lastModified={updatedAt}
         lastModifiedText={updatedAtText}
         category={categoryLink}
+        noTranslate={noTranslate]
       />
       <ArticleBody>
         {structuredBody?.value && (
@@ -105,13 +107,15 @@ const ArticleTemplate = ({
         )}
       </ArticleBody>
     </Section>
-    {relatedPosts.length > 0 && (
+    {relatedPosts.filter(({ noTranslate }) => !noTranslate).length > 0 && (
       <Section>
         <SectionTitle noPaddings css={{ maxWidth: 'var(--articleContainer)' }}>
           {nextReadText}
         </SectionTitle>
         <SectionGridTwoCols>
-          {relatedPosts.map(
+          {relatedPosts
+           .filter(({ noTranslate }) => !noTranslate)
+           .map(
             ({
               id: relatedId,
               meta: { updatedAt: relatedUpdatedAt },
@@ -189,6 +193,7 @@ export const query = graphql`
       }
       relatedPosts {
         id: originalId
+        locale
         meta {
           updatedAt
         }
@@ -220,6 +225,7 @@ export const query = graphql`
         }
         subtitle
         title
+        noTranslate
       }
       structuredBody {
         blocks {


### PR DESCRIPTION
I fixed a bug which occurs while generating recommendation links.
1. Create article A in language J and K, and article B in only language J
2. set article B for "next read" of article A in language J locale
3. Make the English version of article B "unavailable in this language"
4. An error occurs!

I think it's because article A's recommendation is used for global unexpectedly. My fix is not radically effective but it's working.